### PR TITLE
Add setup script for NCP installation and PATH configuration

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+local_bin="$HOME/.local/bin"
+prg_name="$(basename "$0")"
+
+# Get current shell name and its rc file
+shell_name="$(basename "$SHELL")"
+rc_file="$HOME/.${shell_name}rc"
+
+if [ -f "$local_bin/ncp" ];
+then
+    echo "${prg_name}: ncp tool already installed !"
+    exit 0
+fi
+
+mkdir -p "$local_bin"
+if [[ ":$PATH:" != *":${local_bin}:"* ]];
+then
+    echo "${prg_name}: WARNING: '${local_bin}' is not included in PATH env"
+    echo "adding it to PATH env..."
+    
+    # Add path to shell rc file
+    echo 'export PATH="$PATH:$HOME/.local/bin"' >> "$rc_file"; sleep 0.4
+    echo "Added to $rc_file. Please restart your shell or run:"
+    echo "source $rc_file"
+fi
+cp ./ncp "$local_bin"
+echo "${prg_name}: ncp tool was installed successfully !"


### PR DESCRIPTION
This pull request includes a new setup script to install the `ncp` tool in the user's local bin directory and ensure it is included in the PATH environment variable.

Installation script for `ncp`:

* [`setup.sh`](diffhunk://#diff-4209d788ad32c40cbda3c66b3de47eefb929308ca703bb77a6382625986add17R1-R28): Added a script to check if `ncp` is already installed, create the local bin directory if it doesn't exist, add the directory to the PATH if it is not already included, and copy the `ncp` tool to the local bin directory.